### PR TITLE
Add ariadne

### DIFF
--- a/midas/midas/schema.py
+++ b/midas/midas/schema.py
@@ -1,0 +1,15 @@
+from ariadne import QueryType, make_executable_schema
+
+type_defs = """
+    type Query {
+        hello: String!
+    }
+"""
+
+query = QueryType()
+
+@query.field("hello")
+def resolve_hello(*_):
+    return "Hello world!"
+
+schema = make_executable_schema(type_defs, query)

--- a/midas/midas/schema.py
+++ b/midas/midas/schema.py
@@ -1,15 +1,15 @@
 from ariadne import QueryType, make_executable_schema
 
 type_defs = """
-    type Query {
-        hello: String!
-    }
+  type Query {
+    hello: String!
+  }
 """
 
 query = QueryType()
 
 @query.field("hello")
 def resolve_hello(*_):
-    return "Hello world!"
+  return "Hello world!"
 
 schema = make_executable_schema(type_defs, query)

--- a/midas/midas/settings.py
+++ b/midas/midas/settings.py
@@ -39,10 +39,12 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'tradeEngine.apps.TradeengineConfig',
-    'ariadne.contrib.django'
+    'ariadne.contrib.django',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -53,6 +55,8 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'midas.urls'
+
+CORS_ALLOW_ALL_ORIGINS = True
 
 TEMPLATES = [
     {

--- a/midas/midas/settings.py
+++ b/midas/midas/settings.py
@@ -32,13 +32,14 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'tradeEngine.apps.TradeengineConfig',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'tradeEngine.apps.TradeengineConfig',
+    'ariadne.contrib.django'
 ]
 
 MIDDLEWARE = [

--- a/midas/midas/urls.py
+++ b/midas/midas/urls.py
@@ -17,7 +17,6 @@ from django.contrib import admin
 from django.urls import include, path
 
 from ariadne.contrib.django.views import GraphQLView
-# from ariadne.contrib.django import GraphQL
 from .views import HomeView
 from .schema import schema
 

--- a/midas/midas/urls.py
+++ b/midas/midas/urls.py
@@ -17,6 +17,7 @@ from django.contrib import admin
 from django.urls import include, path
 
 from ariadne.contrib.django.views import GraphQLView
+# from ariadne.contrib.django import GraphQL
 from .views import HomeView
 from .schema import schema
 

--- a/midas/midas/urls.py
+++ b/midas/midas/urls.py
@@ -16,10 +16,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
+from ariadne.contrib.django.views import GraphQLView
 from .views import HomeView
+from .schema import schema
 
 urlpatterns = [
     path('', HomeView),
     path('tradeEngine/', include('tradeEngine.urls')),
+    path('graphql/', GraphQLView.as_view(schema=schema), name='graphql'),
     path('admin/', admin.site.urls),
 ]

--- a/midas/midas/urls.py
+++ b/midas/midas/urls.py
@@ -15,8 +15,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
-
 from ariadne.contrib.django.views import GraphQLView
+
 from .views import HomeView
 from .schema import schema
 

--- a/midas/requirement.txt
+++ b/midas/requirement.txt
@@ -6,3 +6,4 @@ pymongo==3.11.2
 python-dotenv==0.15.0
 pytz==2020.4
 sqlparse==0.2.4
+ariadne==0.12.0

--- a/midas/requirement.txt
+++ b/midas/requirement.txt
@@ -7,3 +7,4 @@ python-dotenv==0.15.0
 pytz==2020.4
 sqlparse==0.2.4
 ariadne==0.12.0
+django-cors-headers==3.6.0


### PR DESCRIPTION
this pr adds the `ariadne` library, a schema-first graphql implementation written in python

we can now access this schema from a different port.

The goal is to have this repo act as the backend for a React frontend (repo to be made)